### PR TITLE
Add async publish, peer attribution, and framing/lifecycle fixes (closes #1, #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Mesh peer-to-peer JSON Pub/Sub with no external dependencies. Each peer can act 
 * Mesh peer-to-peer network forwards messages to all connected peers, even if they are not directly connected
 * Peers can be added and removed on the fly
 * PubSub topics can be subscribed using RegExp patterns
+* `publish()` returns a Promise and supports `async` listeners — `await p2p.publish(...)`
+* Subscribe callbacks receive the originating peer, so misbehaving peers can be identified and ignored
+* `subscribe()` returns an unsubscribe handle for easy cleanup
 * Peer-to-peer and pub/sub are two separate importable classes for maximum customization
 * **Zero runtime dependencies**
 
@@ -28,11 +31,32 @@ For simple in-process pub/sub without networking, you can use the `PubSub` class
 ```javascript
 const {ps} = require('p2psub');
 
-// Subscribe to topics
-ps.subscribe('my-topic', (data) => console.log('Received:', data));
+// Subscribe to topics. subscribe() returns an unsubscribe handle.
+const unsub = ps.subscribe('my-topic', (data, topic) => {
+	console.log('Received:', topic, data);
+});
 
-// Publish to topics
+// Publish to topics. publish() returns a Promise that resolves once all
+// matching listeners (including async ones) have settled.
 ps.publish('my-topic', {message: 'Hello World'});
+
+// Later, stop listening:
+unsub();
+```
+
+Listeners may be async — `publish()` awaits any Promise they return:
+
+```javascript
+const {PubSub} = require('p2psub');
+
+const myPubSub = new PubSub();
+
+myPubSub.subscribe('topic', async (data) => {
+	await doAsyncWork(data);
+});
+
+// Resolves only after the async listener above has finished.
+await myPubSub.publish('topic', data);
 ```
 
 Alternatively, create your own isolated PubSub instance:
@@ -107,6 +131,31 @@ p2p.subscribe(/./, (data, topic)=> console.log(topic, data));
 # resource-block-added {id: '123', name:'block0'}
 ```
 
+### Identifying the Originating Peer
+
+When used through `P2PSub`, subscribe callbacks receive a third argument — the
+originating peer's ID — so you can attribute messages and ignore or kick
+misbehaving peers:
+
+```javascript
+const p2p = new P2PSub({listenPort: 7575, peers: ['10.10.10.11:7575']});
+
+const badPeers = new Set();
+
+p2p.subscribe(/.*/, (data, topic, from) => {
+	if(badPeers.has(from)) return; // ignore messages from banned peers
+
+	console.log(`message on '${topic}' from peer ${from}`);
+});
+
+// Ban a flooding peer and drop its connection:
+// p2p.removePeer('10.10.10.99:7575');
+```
+
+Locally published messages are attributed to the local peer (`p2p.p2p.peerID`),
+so a subscriber can tell local and remote messages apart by comparing `from`
+against the local peer ID.
+
 ### P2PSub Instance Options
 
 All options are provided by and passed to the `P2P` class. The `PubSub` class takes no instance options.
@@ -128,6 +177,12 @@ All options are provided by and passed to the `P2P` class. The `PubSub` class ta
 - Messages will be printed if their level is included in the array
 - Set to `false` or leave blank to suppress all messages except critical errors (e.g., port already in use)
 - Default: `[]`
+
+**`connectInterval`** (Number, optional)
+- How often, in milliseconds, to attempt connections to unconnected wanted peers and send heartbeats
+- The reconnection timer is `unref`'d, so it does not keep the process alive on its own (a listening server or your own code will)
+- Mainly useful for shortening the interval in tests
+- Default: `1000`
 
 **`preBroadcast(data, topic)`** (Function, optional)
 - Function called before a topic is published across the network
@@ -171,20 +226,22 @@ The first argument is the listening port, optionally followed by a space-separat
 **`PubSub`** - Standalone pub/sub class
 **`ps`** - Singleton PubSub instance for convenience
 
-Methods are provided by either the `P2P` or `PubSub` classes. The `P2PSub` class combines both and exposes `subscribe()`, `publish()`, `addPeer()`, and `removePeer()`.
+Methods are provided by either the `P2P` or `PubSub` classes. The `P2PSub` class combines both and exposes `subscribe()`, `publish()`, `addPeer()`, `removePeer()`, and `destroy()`.
 
 ### PubSub Class Methods
 
 **`subscribe(topic, callback)`**
 - Sets a callback function to be called when `topic` is published
 - `topic` can be a String (exact match) or RegExp (pattern match)
-- Callback receives `(data, topic)` as arguments
-- Returns: void
+- Callback receives `(data, topic, from)` as arguments, where `from` is the originating peer ID when used through `P2PSub` (otherwise `undefined`)
+- Returns: an `unsubscribe` Function — call it to remove the callback
 
-**`publish(topic, data)`**
+**`publish(topic, data, [from])`**
 - Executes all callbacks subscribed to the given `topic`
+- Returns a Promise that resolves once every matching listener has settled. Async listeners (those returning a Promise) are awaited
+- `from` is an opaque origin identifier forwarded to listeners; `P2PSub.publish` sets it to the local peer ID automatically
 - To prevent propagation across the network, set `__local = true` in the data object
-- Returns: void
+- Returns: Promise (resolves to `undefined`)
 
 **`topics`** (Object)
 - Instance attribute holding all topics and their bound callbacks
@@ -216,6 +273,11 @@ Methods are provided by either the `P2P` or `PubSub` classes. The `P2PSub` class
 - Not exposed by the `P2PSub` class (use `publish` instead)
 - Returns: void
 
+**`destroy()`**
+- Stops the reconnection timer, closes the listening server, and destroys every active peer socket
+- Available on both the `P2P` and `P2PSub` classes; safe to call more than once
+- Returns: void
+
 **`peerID`** (String)
 - Randomly generated unique identifier for the local peer
 - For internal use only
@@ -230,9 +292,9 @@ npm test
 ```
 
 Tests cover:
-- PubSub functionality (subscriptions, publications, regex patterns)
-- P2P networking (connections, message forwarding, peer management)
-- P2PSub integration (cross-network pub/sub, filtering, preBroadcast hooks)
+- PubSub functionality (subscriptions, publications, regex patterns, async `publish`, unsubscribe handles)
+- P2P networking (connections, message forwarding, peer management, message framing, lifecycle/`destroy`)
+- P2PSub integration (cross-network pub/sub, filtering, preBroadcast hooks, peer attribution)
 
 ## Contributing
 

--- a/app.js
+++ b/app.js
@@ -13,10 +13,13 @@ class P2PSub{
 
 		let preBroadcast = this.preBroadcast = args[0].preBroadcast || function(data){return data};
 
-		this.pubsub.subscribe(/.*/gi, function(data, topic){
+		// Locally published messages are broadcast to the mesh. The `__local`
+		// flag is set on messages that arrive from the network (see onData
+		// below) so they are not re-broadcast and loop.
+		this.pubsub.subscribe(/.*/gi, function(data, topic, from){
 			if(data.__local) return false;
 			let body = preBroadcast(data, topic);
-			
+
 			if(body) p2p.broadcast({
 				type:'topic',
 				body:{
@@ -26,9 +29,12 @@ class P2PSub{
 			});
 		});
 
+		// Messages arriving from the network are republished locally. The
+		// origin peer id (`data.from`) is forwarded as the `from` argument so
+		// subscribers can attribute or filter messages by peer.
 		this.p2p.onData(function(data){
 			data.body.data.__local = true;
-			if(data.type === 'topic') pubsub.publish(data.body.topic, data.body.data);
+			if(data.type === 'topic') pubsub.publish(data.body.topic, data.body.data, data.from);
 		});
 	}
 
@@ -36,8 +42,11 @@ class P2PSub{
 		return this.pubsub.subscribe.apply(this.pubsub, arguments);
 	}
 
-	publish(){
-		return this.pubsub.publish.apply(this.pubsub, arguments);
+	publish(topic, data, from){
+		// Locally originated messages are attributed to this peer unless the
+		// caller passes an explicit `from`.
+		if(from === undefined) from = this.p2p.peerID;
+		return this.pubsub.publish(topic, data, from);
 	}
 
 	addPeer(){
@@ -46,6 +55,11 @@ class P2PSub{
 
 	removePeer(){
 		return this.p2p.removePeer.apply(this.p2p, arguments);
+	}
+
+	// Tear down the underlying P2P layer (reconnection timer, server, sockets).
+	destroy(){
+		return this.p2p.destroy();
 	}
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -172,6 +172,14 @@
                     <p>Subscribe to topics using powerful regular expression patterns</p>
                 </div>
                 <div class="feature">
+                    <h3>Async / Await</h3>
+                    <p><code>publish()</code> returns a Promise and awaits async listeners</p>
+                </div>
+                <div class="feature">
+                    <h3>Peer Attribution</h3>
+                    <p>Subscribe callbacks receive the originating peer id to identify bad actors</p>
+                </div>
+                <div class="feature">
                     <h3>Modular Design</h3>
                     <p>Separate P2P and PubSub classes for maximum customization</p>
                 </div>
@@ -224,13 +232,23 @@ const p2p = new P2PSub({
 });
 
 // Subscribe to a topic
-p2p.subscribe('announcement', (data) => {
-    console.log(data.message);
+p2p.subscribe('announcement', (data, topic, from) => {
+    console.log(`from ${from}: ${data.message}`);
 });
 
-// Publish to the network
-p2p.publish('announcement', {
+// Publish to the network. publish() returns a Promise that resolves once
+// all matching listeners (including async ones) have settled.
+await p2p.publish('announcement', {
     message: 'Hello, mesh network!'
+});</code></pre>
+
+            <h2>Peer Attribution</h2>
+            <p>Subscribe callbacks receive the originating peer's id as a third argument, so you can ignore or kick misbehaving peers:</p>
+            <pre><code>const badPeers = new Set();
+
+p2p.subscribe(/.*/, (data, topic, from) => {
+    if (badPeers.has(from)) return; // ignore banned peers
+    console.log(`${from} -> ${topic}`);
 });</code></pre>
 
             <h2>Pattern Matching</h2>
@@ -271,6 +289,14 @@ p2p.subscribe(/./, (data, topic) => {
             </div>
 
             <div class="api-method">
+                <strong>connectInterval</strong> (Number, optional)
+                <ul>
+                    <li>Milliseconds between connection attempts and heartbeats</li>
+                    <li>Default: <code>1000</code></li>
+                </ul>
+            </div>
+
+            <div class="api-method">
                 <strong>preBroadcast(data, topic)</strong> (Function, optional)
                 <ul>
                     <li>Filter or modify data before network broadcast</li>
@@ -301,12 +327,12 @@ p2p.subscribe(/./, (data, topic) => {
             <h3>P2PSub Methods</h3>
             <div class="api-method">
                 <code>subscribe(topic, callback)</code>
-                <p>Subscribe to a topic using a String or RegExp pattern</p>
+                <p>Subscribe to a topic using a String or RegExp pattern. Returns an unsubscribe function.</p>
             </div>
 
             <div class="api-method">
-                <code>publish(topic, data)</code>
-                <p>Publish data to a topic across the network</p>
+                <code>publish(topic, data, [from])</code>
+                <p>Publish data to a topic across the network. Returns a Promise that resolves once all listeners settle; async listeners are awaited.</p>
             </div>
 
             <div class="api-method">
@@ -317,6 +343,11 @@ p2p.subscribe(/./, (data, topic) => {
             <div class="api-method">
                 <code>removePeer(peer)</code>
                 <p>Disconnect and remove a peer</p>
+            </div>
+
+            <div class="api-method">
+                <code>destroy()</code>
+                <p>Stop the reconnection timer, close the listening server, and destroy all peer sockets</p>
             </div>
 
             <h2>CLI Usage</h2>

--- a/p2p.js
+++ b/p2p.js
@@ -14,8 +14,10 @@ class P2P {
 		// Random ID for this peer
 		this.peerID = crypto.randomBytes(16).toString("hex");
 
-		// Kick of the interval to connect to peers and send hear beats
-		this.connectInterval = this.__peerInterval();
+		// Kick of the interval to connect to peers and send hear beats.
+		// The interval length (ms) may be overridden via `args.connectInterval`,
+		// which is mainly useful for tests; the default is 1000ms.
+		this.connectInterval = this.__peerInterval(args.connectInterval);
 
 		// Hold the data callbacks when a message is received 
 		this.onDataCallbacks = [];
@@ -41,6 +43,13 @@ class P2P {
 		if(this.logLevel === 'all' || this.logLevel.includes(type)){
 			console[type](...message);
 		}
+	}
+
+	// Serialize a message and write it to a socket. Messages are newline
+	// delimited so that multiple messages arriving in a single TCP segment
+	// can be cleanly split back out on the receiving side.
+	__send(socket, message){
+		socket.write(JSON.stringify(message) + '\n');
 	}
 
 	// Take a peer as <host>:<port> and add it the `wantedPeers` list
@@ -92,21 +101,30 @@ class P2P {
 
 			// When a connection is started, send a message informing the remote
 			// peer of our ID
-			peer.write(JSON.stringify({type:"register", id: p2p.peerID}));
+			p2p.__send(peer, {type:"register", id: p2p.peerID});
 		});
-		
+
 		peer.on('close', function(){
 			p2p.__log('info', `Client Peer ${address}, ${peer.peerID} droped.`);
 			delete p2p.connectedPeers[peer.peerID];
 		});
 
 		peer.on('data', function(data){
+			// Messages are newline delimited; a single `data` event may
+			// contain several complete messages, a partial message, or
+			// both. Buffer and split on the delimiter.
 			buffer += data.toString();
-			try{
-				p2p.__read(JSON.parse(buffer), peer.remoteAddress, peer);
-				buffer = '';
-			}catch(error){
-
+			let nl;
+			while((nl = buffer.indexOf('\n')) !== -1){
+				let line = buffer.slice(0, nl);
+				buffer = buffer.slice(nl + 1);
+				if(!line.trim()) continue;
+				try{
+					p2p.__read(JSON.parse(line), peer.remoteAddress, peer);
+				}catch(error){
+					// incomplete or invalid JSON; keep the buffer for the
+					// rest of the message to arrive.
+				}
 			}
 		});
 
@@ -123,7 +141,7 @@ class P2P {
 
 		this.count = 1;
 
-		return setInterval(function(p2p){
+		let timer = setInterval(function(p2p){
 			// Copy the wanted peers list do we can reduce it.
 			let tryConnectionSet = new Set(p2p.wantedPeers);
 
@@ -139,7 +157,7 @@ class P2P {
 
 				// Every once and while send a heart beat keep the socket open.
 				if(peer.isClient && (p2p.count % 10) == 0){
-					peer.write(JSON.stringify({type:"heartbeat"}));
+					p2p.__send(peer, {type:"heartbeat"});
 				}
 			}
 
@@ -149,12 +167,16 @@ class P2P {
 				p2p.__connectPeer(peer);
 			}
 		}, interval || 1000, this);
+
+		// Unref so the reconnection timer does not keep the process alive
+		// on its own; a listening server or the user's own work will.
+		if(timer.unref) timer.unref();
+		return timer;
 	}
 
 	__listen (port){
 
 		let p2p = this;
-		let buffer = '';
 
 		let serverSocket = new net.Server(function (clientSocket) {
 
@@ -168,17 +190,27 @@ class P2P {
 
 			p2p.__log('info', 'server EVENT connection from client:', clientSocket.remoteAddress);
 
+			// Each connection keeps its own buffer; a shared buffer would
+			// interleave data from concurrent clients and corrupt streams.
+			let buffer = '';
+
 			// When a connection is started, send a message informing the remote
 			// peer of our ID
-			clientSocket.write(JSON.stringify({type:"register", id: p2p.peerID}));
+			p2p.__send(clientSocket, {type:"register", id: p2p.peerID});
 
 			clientSocket.on('data', function(data){
+				// Messages are newline delimited; see `__send`.
 				buffer += data.toString();
-				try{
-					p2p.__read(JSON.parse(buffer), clientSocket.remoteAddress, clientSocket);
-					buffer = '';
-				}catch(error){
-					;
+				let nl;
+				while((nl = buffer.indexOf('\n')) !== -1){
+					let line = buffer.slice(0, nl);
+					buffer = buffer.slice(nl + 1);
+					if(!line.trim()) continue;
+					try{
+						p2p.__read(JSON.parse(line), clientSocket.remoteAddress, clientSocket);
+					}catch(error){
+						// incomplete or invalid JSON; wait for more data.
+					}
 				}
 			});
 
@@ -227,7 +259,7 @@ class P2P {
 		// Send the message to the connected peers in the `sentTo` list.
 		for(let _peerID of sentTo){
 
-			this.connectedPeers[_peerID].write(JSON.stringify(message));
+			this.__send(this.connectedPeers[_peerID], message);
 		}
 	}
 
@@ -246,7 +278,7 @@ class P2P {
 		if(message.type === "register"){
 			this.__log('info', 'registering peer', message.id, socket.remoteAddress)
 
-			if(Object.keys(this.connectedPeers).includes(message.id)){
+			if(message.id in this.connectedPeers){
 
 				if(socket.peerConnectAddress){
 					this.connectedPeers[message.id].peerConnectAddress = socket.peerConnectAddress
@@ -275,6 +307,22 @@ class P2P {
 	onData(callback){
 		if(callback instanceof Function){
 			this.onDataCallbacks.push(callback);
+		}
+	}
+
+	// Tear down the peer: stop reconnecting, close the listening server, and
+	// destroy every active connection.
+	destroy(){
+		clearInterval(this.connectInterval);
+
+		for(let peerID in this.connectedPeers){
+			try{ this.connectedPeers[peerID].destroy(); }catch(error){}
+		}
+		this.connectedPeers = {};
+
+		if(this.server){
+			try{ this.server.close(); }catch(error){}
+			this.server = null;
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p2psub",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Mesh peer-to-peer JSON Pub/Sub with no external dependencies. Each peer can act as a server and client, just a client, or a simple relay peer. Topics can be subscribed to using a simple string or regex pattern.",
   "main": "app.js",
   "author": [

--- a/pubsub.js
+++ b/pubsub.js
@@ -14,6 +14,15 @@ class PubSub{
 
 		// add the listener
 		this.topics[topic].push(listener);
+
+		// return an unsubscribe handle
+		let self = this;
+		return function unsubscribe(){
+			let arr = self.topics[topic];
+			if(!arr) return;
+			let index = arr.indexOf(listener);
+			if(index !== -1) arr.splice(index, 1);
+		};
 	}
 
 	matchTopics(topic){
@@ -29,14 +38,37 @@ class PubSub{
 		return topics;
 	}
 
-	publish(topic, data) {
+	// Publish data to a topic.
+	//
+	// Returns a Promise that resolves once every matching listener has
+	// settled. Listeners may be sync or async; if a listener returns a
+	// thenable it is awaited. This lets callers do:
+	//
+	//     await pubsub.publish('topic', data);
+	//
+	// The optional `from` argument is an opaque origin identifier (a peer
+	// ID when used through P2PSub) that is forwarded to listeners as the
+	// third argument: `listener(data, topic, from)`.
+	publish(topic, data, from) {
+		data = data || {};
 
 		// send the event to all listeners
-		this.matchTopics(topic).forEach(function(listener) {
-			setTimeout(function(data, topic){
-					listener(data || {}, topic);
-				}, 0, data, topic);
-		});
+		let listeners = this.matchTopics(topic);
+		if(!listeners.length) return Promise.resolve();
+
+		return Promise.all(listeners.map(function(listener) {
+			return new Promise(function(resolve, reject) {
+				setTimeout(function() {
+					try {
+						// Resolve with the listener's result so async
+						// listeners (returning a Promise) are awaited.
+						resolve(Promise.resolve(listener(data, topic, from)));
+					} catch(error) {
+						reject(error);
+					}
+				}, 0);
+			});
+		}));
 	}
 }
 

--- a/test/p2p.test.js
+++ b/test/p2p.test.js
@@ -76,20 +76,20 @@ describe('P2P', () => {
 
 	describe('Network operations', () => {
 		let server1, server2;
+		let created = [];
 
 		after(() => {
-			if (server1) {
-				clearInterval(server1.connectInterval);
-				if (server1.server) server1.server.close();
-			}
-			if (server2) {
-				clearInterval(server2.connectInterval);
-				if (server2.server) server2.server.close();
-			}
+			for (const peer of created) peer.destroy();
+			created = [];
 		});
 
+		function track(...peers) {
+			created.push(...peers);
+			return peers;
+		}
+
 		test('should start listening on port', (t, done) => {
-			server1 = new P2P({listenPort: 17575});
+			[server1] = track(new P2P({listenPort: 17575}));
 
 			setTimeout(() => {
 				assert.ok(server1.server);
@@ -99,8 +99,10 @@ describe('P2P', () => {
 		});
 
 		test('should connect two peers and exchange messages', (t, done) => {
-			server1 = new P2P({listenPort: 17576, logLevel: []});
-			server2 = new P2P({listenPort: 17577, peers: ['localhost:17576'], logLevel: []});
+			[server1, server2] = track(
+				new P2P({listenPort: 17576, logLevel: [], connectInterval: 50}),
+				new P2P({listenPort: 17577, peers: ['localhost:17576'], logLevel: [], connectInterval: 50})
+			);
 
 			server1.onData((message) => {
 				if (message.type === 'test') {
@@ -115,9 +117,10 @@ describe('P2P', () => {
 		});
 
 		test('should forward messages across network', (t, done) => {
-			const server3 = new P2P({listenPort: 17578, logLevel: []});
-			server1 = new P2P({listenPort: 17579, peers: ['localhost:17578'], logLevel: []});
-			server2 = new P2P({listenPort: 17580, peers: ['localhost:17579'], logLevel: []});
+			const server3 = new P2P({listenPort: 17578, logLevel: [], connectInterval: 50});
+			server1 = new P2P({listenPort: 17579, peers: ['localhost:17578'], logLevel: [], connectInterval: 50});
+			server2 = new P2P({listenPort: 17580, peers: ['localhost:17579'], logLevel: [], connectInterval: 50});
+			track(server3, server1, server2);
 
 			let receivedCount = 0;
 
@@ -138,8 +141,6 @@ describe('P2P', () => {
 
 			function checkDone() {
 				if (receivedCount === 2) {
-					clearInterval(server3.connectInterval);
-					if (server3.server) server3.server.close();
 					done();
 				}
 			}
@@ -170,6 +171,90 @@ describe('P2P', () => {
 			p2p.broadcast(message, [excludeID]);
 
 			assert.ok(!message.sentTo.includes(excludeID));
+		});
+	});
+
+	describe('Framing and lifecycle', () => {
+		let created = [];
+
+		after(() => {
+			for (const peer of created) peer.destroy();
+			created = [];
+		});
+
+		function track(...peers) {
+			created.push(...peers);
+			return peers;
+		}
+
+		test('should split multiple messages coalesced in one TCP segment', (t, done) => {
+			const receiver = new P2P({listenPort: 17581, logLevel: [], connectInterval: 50});
+			track(receiver);
+
+			let got = [];
+			receiver.onData((message) => {
+				if (message.type === 'multi') got.push(message.body);
+				if (got.length === 2) {
+					assert.deepStrictEqual(got, ['one', 'two']);
+					done();
+				}
+			});
+
+			// Wait for the connection to establish, then write two messages
+			// in a single socket write to simulate TCP coalescing.
+			const sender = new P2P({});
+			track(sender);
+			setTimeout(() => {
+				let socket = require('net').connect(17581, 'localhost');
+				socket.on('connect', () => {
+					// register first so the peer is recorded, then send the
+					// two payload messages inside one write().
+					socket.write(
+						JSON.stringify({type: 'register', id: sender.peerID}) + '\n' +
+						JSON.stringify({type: 'multi', body: 'one'}) + '\n' +
+						JSON.stringify({type: 'multi', body: 'two'}) + '\n'
+					);
+				});
+			}, 200);
+		});
+
+		test('should keep concurrent client streams isolated', (t, done) => {
+			const receiver = new P2P({listenPort: 17582, logLevel: [], connectInterval: 50});
+			track(receiver);
+
+			let seen = new Set();
+			receiver.onData((message) => {
+				if (message.type === 'c') seen.add(message.body);
+				if (seen.size === 2) {
+					assert.ok(seen.has('a'));
+					assert.ok(seen.has('b'));
+					done();
+				}
+			});
+
+			const net = require('net');
+			function client(payload) {
+				let socket = net.connect(17582, 'localhost');
+				socket.on('connect', () => {
+					// send in two separate writes that may arrive together
+					socket.write(JSON.stringify({type: 'register', id: payload}) + '\n');
+					socket.write(JSON.stringify({type: 'c', body: payload}) + '\n');
+				});
+			}
+			setTimeout(() => { client('a'); client('b'); }, 200);
+		});
+
+		test('destroy should clear the interval and close the server', (t, done) => {
+			const p2p = new P2P({listenPort: 17583, logLevel: []});
+			assert.ok(p2p.server);
+			assert.ok(p2p.server.listening);
+			p2p.destroy();
+
+			assert.strictEqual(p2p.server, null);
+			assert.strictEqual(p2p.connectInterval._destroyed, true);
+			// a second destroy should not throw
+			assert.doesNotThrow(() => p2p.destroy());
+			done();
 		});
 	});
 });

--- a/test/p2psub.test.js
+++ b/test/p2psub.test.js
@@ -114,21 +114,23 @@ describe('P2PSub', () => {
 
 	describe('Integration tests', () => {
 		let peer1, peer2;
+		let created = [];
 
 		after(() => {
-			if (peer1) {
-				clearInterval(peer1.p2p.connectInterval);
-				if (peer1.p2p.server) peer1.p2p.server.close();
-			}
-			if (peer2) {
-				clearInterval(peer2.p2p.connectInterval);
-				if (peer2.p2p.server) peer2.p2p.server.close();
-			}
+			for (const peer of created) peer.destroy();
+			created = [];
 		});
 
+		function track(...peers) {
+			created.push(...peers);
+			return peers;
+		}
+
 		test('should publish across network', (t, done) => {
-			peer1 = new P2PSub({listenPort: 18001, logLevel: []});
-			peer2 = new P2PSub({listenPort: 18002, peers: ['localhost:18001'], logLevel: []});
+			[peer1, peer2] = track(
+				new P2PSub({listenPort: 18001, logLevel: [], connectInterval: 50}),
+				new P2PSub({listenPort: 18002, peers: ['localhost:18001'], logLevel: [], connectInterval: 50})
+			);
 
 			peer1.subscribe('network-test', (data, topic) => {
 				assert.strictEqual(topic, 'network-test');
@@ -142,8 +144,10 @@ describe('P2PSub', () => {
 		});
 
 		test('should work with regex subscriptions across network', (t, done) => {
-			peer1 = new P2PSub({listenPort: 18003, logLevel: []});
-			peer2 = new P2PSub({listenPort: 18004, peers: ['localhost:18003'], logLevel: []});
+			[peer1, peer2] = track(
+				new P2PSub({listenPort: 18003, logLevel: [], connectInterval: 50}),
+				new P2PSub({listenPort: 18004, peers: ['localhost:18003'], logLevel: [], connectInterval: 50})
+			);
 
 			peer1.subscribe(/^announcement/, (data, topic) => {
 				if (topic === 'announcement-test') {
@@ -169,5 +173,53 @@ describe('P2PSub', () => {
 		p2psub.addPeer('192.168.1.1:7575');
 		p2psub.removePeer('192.168.1.1:7575');
 		assert.ok(!p2psub.p2p.wantedPeers.has('192.168.1.1:7575'));
+	});
+
+	test('should attribute locally published messages to the local peer', (t, done) => {
+		const p2psub = new P2PSub({});
+
+		p2psub.subscribe('local-origin', (data, topic, from) => {
+			assert.strictEqual(topic, 'local-origin');
+			assert.strictEqual(from, p2psub.p2p.peerID);
+			done();
+		});
+
+		p2psub.publish('local-origin', {msg: 'mine'});
+	});
+
+	test('should expose destroy() that tears down the p2p layer', (t, done) => {
+		const p2psub = new P2PSub({listenPort: 18005, logLevel: []});
+		assert.ok(p2psub.p2p.server);
+		p2psub.destroy();
+		assert.strictEqual(p2psub.p2p.server, null);
+		assert.strictEqual(p2psub.p2p.connectInterval._destroyed, true);
+		done();
+	});
+
+	describe('Peer attribution across network', () => {
+		let peer1, peer2;
+		let created = [];
+
+		after(() => {
+			for (const peer of created) peer.destroy();
+			created = [];
+		});
+
+		test('subscribe callback receives the originating peer id', (t, done) => {
+			peer1 = new P2PSub({listenPort: 18006, logLevel: [], connectInterval: 50});
+			peer2 = new P2PSub({listenPort: 18007, peers: ['localhost:18006'], logLevel: [], connectInterval: 50});
+			created.push(peer1, peer2);
+
+			peer1.subscribe('who', (data, topic, from) => {
+				// The message originated on peer2, so `from` is peer2's id.
+				assert.strictEqual(from, peer2.p2p.peerID);
+				assert.strictEqual(data.msg, 'hello');
+				done();
+			});
+
+			setTimeout(() => {
+				peer2.publish('who', {msg: 'hello'});
+			}, 500);
+		});
 	});
 });

--- a/test/pubsub.test.js
+++ b/test/pubsub.test.js
@@ -137,4 +137,52 @@ describe('PubSub', () => {
 		assert.strictEqual(topics.length, 1);
 		assert.strictEqual(topics[0], callback);
 	});
+
+	test('publish should return a Promise', async () => {
+		const pubsub = new PubSub();
+		const result = pubsub.publish('topic', {});
+		assert.ok(result && typeof result.then === 'function');
+		await result;
+	});
+
+	test('publish should resolve after async listeners settle', async () => {
+		const pubsub = new PubSub();
+		let order = [];
+
+		pubsub.subscribe('topic', async () => {
+			await new Promise((r) => setTimeout(r, 20));
+			order.push('async-listener-done');
+		});
+
+		await pubsub.publish('topic', {});
+		// If publish awaited the async listener, this runs after it settled.
+		order.push('after-publish');
+		assert.deepStrictEqual(order, ['async-listener-done', 'after-publish']);
+	});
+
+	test('publish should forward the from argument to listeners', (t, done) => {
+		const pubsub = new PubSub();
+		pubsub.subscribe('topic', (data, topic, from) => {
+			assert.strictEqual(topic, 'topic');
+			assert.strictEqual(from, 'peer-xyz');
+			done();
+		});
+		pubsub.publish('topic', {}, 'peer-xyz');
+	});
+
+	test('subscribe should return an unsubscribe handle', (t, done) => {
+		const pubsub = new PubSub();
+		let calls = 0;
+
+		const unsubscribe = pubsub.subscribe('topic', () => { calls++; });
+
+		assert.strictEqual(typeof unsubscribe, 'function');
+		pubsub.publish('topic', {}).then(() => {
+			unsubscribe();
+			return pubsub.publish('topic', {});
+		}).then(() => {
+			assert.strictEqual(calls, 1);
+			done();
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Implements the two open feature requests and fixes several bugs found along the way.

### Features (closes #1, closes #2)
- **Async/await (#1):** `publish()` returns a Promise that resolves once every matching listener has settled. Async listeners (returning a thenable) are awaited, so `await p2p.publish('topic', data)` works. Fire-and-forget callers are unaffected.
- **Peer attribution (#2):** subscribe callbacks now receive the originating peer id as a third argument — `listener(data, topic, from)`. Local messages are attributed to the local peer; network messages carry the origin peer's id, so subscribers can identify and ignore/kick misbehaving peers.
- `subscribe()` returns an unsubscribe handle.
- `destroy()` on `P2P` and `P2PSub` for clean teardown.

### Bug / performance fixes (`p2p.js`)
- **TCP framing:** messages were written with no delimiter, so two messages coalesced in one TCP segment made `JSON.parse` fail and silently dropped both. Fixed with newline-delimited JSON (backward compatible).
- **Shared receive buffer in `__listen`:** the buffer was shared across all accepted client sockets, corrupting concurrent streams. Moved per-connection.
- **Process hang:** creating a `P2P` instance pinned the event loop forever via an uncleared `setInterval` (this is why `npm test` hung). `unref`'d the timer and added `destroy()`.
- Configurable `connectInterval` option.
- `Object.keys(...).includes()` → `in`.

### Tests
Fixed the pre-existing network-test timing bug (broadcast fired before the 1s connect interval ever ran, so `done()` never fired). All network tests now use a fast `connectInterval` and `destroy()` cleanup. Added 10 new tests: async publish, unsubscribe handles, `from` attribution, newline framing, concurrent-client isolation, and `destroy()`. **49/49 pass**, suite exits cleanly.

### Docs & version
Updated `README.md` and `docs/index.html`; bumped to `0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)