### PR TITLE
Add TypeScript declarations, fix CLI/constructor edge cases, expand tests, and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ Mesh peer-to-peer JSON Pub/Sub with no external dependencies. Each peer can act 
 npm install p2psub
 ```
 
+Requires Node.js **>= 18.0.0** (the test suite uses the built-in `node:test` runner).
+
+## TypeScript Support
+
+p2psub ships with TypeScript declarations. Import the classes directly:
+
+```typescript
+import {P2PSub, P2P, PubSub, ps} from 'p2psub';
+
+const p2p = new P2PSub({
+    listenPort: 7575,
+    peers: ['10.10.10.11:7575']
+});
+```
 
 ## Usage
 
@@ -211,11 +225,19 @@ const p2p = new P2PSub({
 
 A simple relay peer can be set up using just the CLI, no code required. This peer will only relay messages to all its connected peers. The logging level is automatically set to `info`.
 
+If the package is installed globally or run with `npx`:
+
+```bash
+npx p2psub 7575 10.1.0.1:7575 10.2.0.1:7575 10.3.0.1:7575 ...
+```
+
+Or, when running from the repository directly:
+
 ```bash
 ./app.js 7575 10.1.0.1:7575 10.2.0.1:7575 10.3.0.1:7575 ...
 ```
 
-The first argument is the listening port, optionally followed by a space-separated list of peers to connect with.
+The first argument is the listening port, optionally followed by a space-separated list of peers to connect with. Run with `help` (or omit the port) to print usage instructions.
 
 ## API Reference
 

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env nodejs
+#!/usr/bin/env node
 
 const {PubSub} = require('./pubsub');
 const {P2P} = require('./p2p');
@@ -7,11 +7,12 @@ const ps = new PubSub();
 
 class P2PSub{
 	constructor(...args){
-		let p2p = this.p2p = new P2P(...args);
+		let options = args[0] || {};
+		let p2p = this.p2p = new P2P(options);
 
 		let pubsub = this.pubsub = new PubSub();
 
-		let preBroadcast = this.preBroadcast = args[0].preBroadcast || function(data){return data};
+		let preBroadcast = this.preBroadcast = options.preBroadcast || function(data){return data};
 
 		// Locally published messages are broadcast to the mesh. The `__local`
 		// flag is set on messages that arrive from the network (see onData
@@ -73,11 +74,11 @@ if (require.main === module) {
 	const listenPort = args[1];
 	const peers = args.slice(2);
 
-	if(listenPort === "help"){
+	if(!listenPort || listenPort === "help"){
 		console.error('Please supply the server port and list of clients to connect too;')
 		console.error(`${exec_name} <server port> <client 1> <client 2> <client 3> ...` )
 		console.error(`${exec_name} 7575 10.1.0.1:7575 10.2.0.1:7575 10.3.0.1:7575` )
-		process.exit(0)
+		process.exit(listenPort === "help" ? 0 : 1)
 	}
 
 	// console.log('port:', server_port, 'clients:', clients_list)

--- a/docs/index.html
+++ b/docs/index.html
@@ -191,12 +191,26 @@
                     <h3>Easy to Use</h3>
                     <p>Simple API with CLI support for quick relay setup</p>
                 </div>
+                <div class="feature">
+                    <h3>TypeScript Ready</h3>
+                    <p>Built-in TypeScript declarations with full API coverage</p>
+                </div>
             </div>
 
             <h2>Installation</h2>
             <pre><code>npm install p2psub</code></pre>
+            <p>Requires Node.js <strong>>= 18.0.0</strong>.</p>
             <a href="https://www.npmjs.com/package/p2psub" class="install-btn">View on NPM</a>
             <a href="https://github.com/wmantly/p2psub" class="install-btn">View on GitHub</a>
+
+            <h2>TypeScript Support</h2>
+            <p>p2psub ships with built-in TypeScript declarations. Import the classes directly:</p>
+            <pre><code>import {P2PSub, P2P, PubSub, ps} from 'p2psub';
+
+const p2p = new P2PSub({
+    listenPort: 7575,
+    peers: ['10.10.10.11:7575']
+});</code></pre>
 
             <h2>Quick Start</h2>
 
@@ -351,7 +365,10 @@ p2p.subscribe(/./, (data, topic) => {
             </div>
 
             <h2>CLI Usage</h2>
-            <p>Set up a simple relay peer without writing code:</p>
+            <p>Set up a simple relay peer without writing code. The logging level is automatically set to <code>info</code>.</p>
+            <p>With <code>npx</code> or a global install:</p>
+            <pre><code>npx p2psub 7575 10.1.0.1:7575 10.2.0.1:7575</code></pre>
+            <p>Or run directly from the repository:</p>
             <pre><code>./app.js 7575 10.1.0.1:7575 10.2.0.1:7575</code></pre>
 
             <h2>Testing</h2>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,116 @@
+// Type definitions for p2psub
+// Project: https://github.com/wmantly/p2psub
+
+export interface PubSubListener {
+	(data: any, topic: string, from?: string): any;
+	match?: RegExp;
+}
+
+export declare class PubSub {
+	topics: Record<string, PubSubListener[]>;
+
+	/**
+	 * Subscribe to a topic. `topic` can be an exact string or a RegExp pattern.
+	 * Returns an unsubscribe function.
+	 */
+	subscribe(topic: string | RegExp, listener: PubSubListener): () => void;
+
+	/**
+	 * Return all listeners that match the given topic name.
+	 */
+	matchTopics(topic: string): PubSubListener[];
+
+	/**
+	 * Publish data to a topic. Returns a Promise that resolves once every
+	 * matching listener has settled. Async listeners are awaited.
+	 */
+	publish(topic: string, data?: any, from?: string): Promise<any>;
+}
+
+export interface P2POptions {
+	/** TCP port to listen on. If omitted, the peer will not accept incoming connections. */
+	listenPort?: number | string;
+
+	/** Peers to connect to, each as `{host}:{port}`. */
+	peers?: string | string[];
+
+	/** Logging levels to enable. Set to `false` to suppress logging. */
+	logLevel?: string[] | false;
+
+	/**
+	 * Milliseconds between connection attempts and heartbeats.
+	 * @default 1000
+	 */
+	connectInterval?: number;
+}
+
+export interface P2PMessage {
+	type: string;
+	[id: string]: any;
+}
+
+export declare class P2P {
+	peerID: string;
+	wantedPeers: Set<string>;
+	connectedPeers: Record<string, any>;
+	logLevel: string[] | false;
+	server?: any;
+	connectInterval: any;
+	onDataCallbacks: Array<(message: P2PMessage) => void>;
+
+	constructor(args?: P2POptions);
+
+	/** Add a peer address or array of addresses to the wanted-peers list. */
+	addPeer(peer: string | string[]): void;
+
+	/** Disconnect and remove a peer from the wanted-peers list. */
+	removePeer(peer: string): void;
+
+	/** Broadcast a message to all connected peers. */
+	broadcast(message: P2PMessage, exclude?: string[]): void;
+
+	/** Register a callback to be invoked when this peer receives a message. */
+	onData(callback: (message: P2PMessage) => void): void;
+
+	/** Tear down the peer: stop reconnecting, close the server, and destroy sockets. */
+	destroy(): void;
+}
+
+export interface P2PSubOptions extends P2POptions {
+	/**
+	 * Called before a locally published message is broadcast to the mesh.
+	 * Return the data object to send, or `false` to prevent broadcasting.
+	 */
+	preBroadcast?(data: any, topic: string): any | false;
+}
+
+export declare class P2PSub {
+	p2p: P2P;
+	pubsub: PubSub;
+
+	constructor(args?: P2PSubOptions);
+
+	/**
+	 * Subscribe to a topic. `topic` can be an exact string or a RegExp pattern.
+	 * Returns an unsubscribe function.
+	 */
+	subscribe(topic: string | RegExp, listener: PubSubListener): () => void;
+
+	/**
+	 * Publish data to a topic. Returns a Promise that resolves once every
+	 * matching listener has settled. The message is attributed to the local peer.
+	 */
+	publish(topic: string, data?: any, from?: string): Promise<any>;
+
+	/** Add a peer address or array of addresses. */
+	addPeer(peer: string | string[]): void;
+
+	/** Disconnect and remove a peer. */
+	removePeer(peer: string): void;
+
+	/** Tear down the underlying P2P layer. */
+	destroy(): void;
+}
+
+/** Singleton PubSub instance for convenience. */
+export declare const ps: PubSub;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,19 @@
 {
   "name": "p2psub",
-  "version": "0.1.9",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p2psub",
-      "version": "0.1.9",
-      "license": "MIT"
+      "version": "0.4.0",
+      "license": "MIT",
+      "bin": {
+        "p2psub": "app.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,22 @@
 {
   "name": "p2psub",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Mesh peer-to-peer JSON Pub/Sub with no external dependencies. Each peer can act as a server and client, just a client, or a simple relay peer. Topics can be subscribed to using a simple string or regex pattern.",
   "main": "app.js",
-  "author": [
-    {
-      "name": "William Mantly",
-      "email": "wmantly@gmail.com"
-    }
+  "types": "index.d.ts",
+  "bin": "app.js",
+  "files": [
+    "app.js",
+    "p2p.js",
+    "pubsub.js",
+    "index.d.ts",
+    "docs/",
+    "README.md",
+    "LICENSE"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "test": "node --test test/*.test.js"
   },
@@ -24,5 +32,11 @@
       "type": "git",
       "url": "https://github.com/wmantly/p2psub"
     },
+  "author": [
+    {
+      "name": "William Mantly",
+      "email": "wmantly@gmail.com"
+    }
+  ],
   "license": "MIT"
 }

--- a/test/p2psub.test.js
+++ b/test/p2psub.test.js
@@ -10,6 +10,13 @@ describe('P2PSub', () => {
 		assert.ok(p2psub.pubsub);
 	});
 
+	test('should create instance with no arguments', () => {
+		const p2psub = new P2PSub();
+		assert.ok(p2psub);
+		assert.ok(p2psub.p2p);
+		assert.ok(p2psub.pubsub);
+	});
+
 	test('should expose subscribe method', () => {
 		const p2psub = new P2PSub({});
 		assert.strictEqual(typeof p2psub.subscribe, 'function');
@@ -173,6 +180,19 @@ describe('P2PSub', () => {
 		p2psub.addPeer('192.168.1.1:7575');
 		p2psub.removePeer('192.168.1.1:7575');
 		assert.ok(!p2psub.p2p.wantedPeers.has('192.168.1.1:7575'));
+	});
+
+	test('should add and remove an array of peers dynamically', () => {
+		const p2psub = new P2PSub({});
+		const peers = ['192.168.1.1:7575', '192.168.1.2:7575'];
+
+		p2psub.addPeer(peers);
+		assert.strictEqual(p2psub.p2p.wantedPeers.size, 2);
+
+		p2psub.removePeer(peers[0]);
+		assert.strictEqual(p2psub.p2p.wantedPeers.size, 1);
+		assert.ok(!p2psub.p2p.wantedPeers.has(peers[0]));
+		assert.ok(p2psub.p2p.wantedPeers.has(peers[1]));
 	});
 
 	test('should attribute locally published messages to the local peer', (t, done) => {

--- a/test/pubsub.test.js
+++ b/test/pubsub.test.js
@@ -185,4 +185,30 @@ describe('PubSub', () => {
 			done();
 		});
 	});
+
+	test('unsubscribe handle should work for regex subscriptions', (t, done) => {
+		const pubsub = new PubSub();
+		let calls = 0;
+
+		const unsubscribe = pubsub.subscribe(/^topic/, () => { calls++; });
+
+		pubsub.publish('topic-one', {}).then(() => {
+			unsubscribe();
+			return pubsub.publish('topic-two', {});
+		}).then(() => {
+			assert.strictEqual(calls, 1);
+			done();
+		});
+	});
+
+	test('publish should reject when a listener throws', async () => {
+		const pubsub = new PubSub();
+		const error = new Error('listener error');
+
+		pubsub.subscribe('topic', () => {
+			throw error;
+		});
+
+		await assert.rejects(pubsub.publish('topic', {}), error);
+	});
 });


### PR DESCRIPTION
This PR adds TypeScript bindings and a handful of small fixes/polish items.

## What's new
- **TypeScript support**: adds `index.d.ts` with declarations for `PubSub`, `P2P`, `P2PSub`, option interfaces, and the `ps` singleton.
- **Package metadata**: adds `types`, `bin`, `files`, and `engines` fields to `package.json`; bumps version to `0.4.0`.

## Fixes
- Corrects the CLI shebang from `#!/usr/bin/env nodejs` to `#!/usr/bin/env node`.
- Guards the `P2PSub` constructor against being called with no arguments (`new P2PSub()`).
- Prints help and exits with a non-zero code when the CLI is run without a port.

## Tests & docs
- Adds tests for regex unsubscribe, listener errors rejecting `publish()`, no-arg `P2PSub` construction, and add/remove of peer arrays.
- Updates `README.md` and the docs site to mention TypeScript support, `npx p2psub`, and the Node >= 18 requirement.

All 53 tests pass.